### PR TITLE
Tests that api_key is not null

### DIFF
--- a/spec/requests/api/v1/registration.spec.js
+++ b/spec/requests/api/v1/registration.spec.js
@@ -31,6 +31,7 @@ describe('api', () => {
           .then(response => {
             expect(response.status).toBe(201),
             expect.objectContaining({ api_key: expect.any(String)}),
+            expect(response.body["api_key"]).not.toBe(null),
             expect(response.body["api_key"].length).toBeGreaterThan(0);
         });
       });


### PR DESCRIPTION
## What functionality does this accomplish?
Adds more robust test based on @chakeresa 's suggestion.

**Tests that api_key is not null**
Made this change based on @chakeresa 's feedback on [user_registration](https://github.com/james-cape/express_sweater_weather/pull/18)'s pull request.
It is a bit redundant in this case, but I am including it for future reference.